### PR TITLE
An error in the readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ How to implement
       ....
    }
    ```
-3. Each <b>Fragment</b> or <b>Activity</b> that you would like to associate with a ViewModel will need either to extend [ViewModelActivityBase](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java)/[ViewModelActivityBase](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java) or copy the implementation from these classes to your base activity/fragment class (in case you can't inherit directly). Override ```getViewModelClass()``` to return the corresponding ViewModel class. For example: <br/>
+3. Each <b>Fragment</b> or <b>Activity</b> that you would like to associate with a ViewModel will need either to extend [ViewModelActivityBase](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java)/[ViewModelBaseFragment](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java) or copy the implementation from these classes to your base activity/fragment class (in case you can't inherit directly). Override ```getViewModelClass()``` to return the corresponding ViewModel class. For example: <br/>
   
   ```java
   public class UserListFragment extends ViewModelBaseFragment<IUserListView, UserListViewModel> 


### PR DESCRIPTION
Changed ViewModelActivityBase to ViewModelBaseFragment. The hyperlink redirected to the ViewModelBaseFragment class, but the reference said ViewModelActivityBase.