### PR TITLE
Remove reflection, add viewmodel factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,23 @@ How to implement
       ....
    }
    ```
-3. Each <b>Fragment</b> or <b>Activity</b> that you would like to associate with a ViewModel will need either to extend [ViewModelActivityBase](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java)/[ViewModelBaseFragment](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java) or copy the implementation from these classes to your base activity/fragment class (in case you can't inherit directly). Override ```getViewModelClass()``` to return the corresponding ViewModel class. For example: <br/>
+3. Each <b>Fragment</b> or <b>Activity</b> that you would like to associate with a ViewModel will need either to extend [ViewModelActivityBase](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java)/[ViewModelBaseFragment](library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java) or copy the implementation from these classes to your base activity/fragment class (in case you can't inherit directly). Override ```getViewModelFactory()``` to return a ViewModelFactory which produces the corresponding ViewModel class. For example: <br/>
   
    ```java
    public class UserListFragment extends ViewModelBaseFragment<IUserListView, UserListViewModel> 
       implements IUserListView {
       
-     @Override
-      public Class<UserListViewModel> getViewModelClass() {
-          return UserListViewModel.class;
-      }
+        @Nullable
+        @Override
+        public IViewModelFactory<IView> getViewModelFactory() {
+            return new IViewModelFactory<IView>() {
+                @NonNull
+                @Override
+                public AbstractViewModel<IView> createViewModel() {
+                    return new UserListViewModel();
+                }
+            };
+        }
       
    }
    ```

--- a/library/src/main/java/eu/inloop/viewmodel/IViewModelFactory.java
+++ b/library/src/main/java/eu/inloop/viewmodel/IViewModelFactory.java
@@ -1,0 +1,9 @@
+package eu.inloop.viewmodel;
+
+import android.support.annotation.NonNull;
+
+public interface IViewModelFactory <T extends IView> {
+
+    @NonNull
+    AbstractViewModel<T> createViewModel();
+}

--- a/library/src/main/java/eu/inloop/viewmodel/IViewModelProvider.java
+++ b/library/src/main/java/eu/inloop/viewmodel/IViewModelProvider.java
@@ -2,14 +2,16 @@ package eu.inloop.viewmodel;
 
 import android.support.annotation.Nullable;
 
+import eu.inloop.viewmodel.base.ViewModelBaseActivity;
+
 /**
  * Your {@link android.app.Activity} must implement this interface if
- * any of the contained Fragments the {@link eu.inloop.viewmodel.ViewModelHelper}
+ * any of the contained Fragments the {@link ViewModelHelper}
  */
 public interface IViewModelProvider {
 
     /**
-     * See {@link eu.inloop.viewmodel.base.ViewModelBaseActivity} on how to implement.
+     * See {@link ViewModelBaseActivity} on how to implement.
      * @return the {@link ViewModelProvider}.
      */
     @Nullable

--- a/library/src/main/java/eu/inloop/viewmodel/ViewModelHelper.java
+++ b/library/src/main/java/eu/inloop/viewmodel/ViewModelHelper.java
@@ -30,16 +30,16 @@ public class ViewModelHelper<T extends IView, R extends AbstractViewModel<T>> {
      * @param activity parent activity
      * @param savedInstanceState savedInstance state from {@link Activity#onCreate(Bundle)} or
      *                           {@link Fragment#onCreate(Bundle)}
-     * @param viewModelClass the {@link Class} of your ViewModel
+     * @param viewModelFactory the {@link Class} of your ViewModel
      * @param arguments pass {@link Fragment#getArguments()}  or
      *                  {@link Activity#getIntent()}.{@link Intent#getExtras() getExtras()}
      */
     public void onCreate(@NonNull Activity activity,
                          @Nullable Bundle savedInstanceState,
-                         @Nullable Class<? extends AbstractViewModel<T>> viewModelClass,
+                         @Nullable IViewModelFactory<T> viewModelFactory,
                          @Nullable Bundle arguments) {
         // no viewmodel for this fragment
-        if (viewModelClass == null) {
+        if (viewModelFactory == null) {
             mViewModel = null;
             return;
         }
@@ -63,7 +63,7 @@ public class ViewModelHelper<T extends IView, R extends AbstractViewModel<T>> {
             throw new IllegalStateException("ViewModelProvider for activity " + activity + " was null."); //NON-NLS
         }
         
-        final ViewModelProvider.ViewModelWrapper<T> viewModelWrapper = viewModelProvider.getViewModel(mScreenId, viewModelClass);
+        final ViewModelProvider.ViewModelWrapper<T> viewModelWrapper = viewModelProvider.getViewModel(mScreenId, viewModelFactory);
         //noinspection unchecked
         mViewModel = (R) viewModelWrapper.viewModel;
 

--- a/library/src/main/java/eu/inloop/viewmodel/ViewModelProvider.java
+++ b/library/src/main/java/eu/inloop/viewmodel/ViewModelProvider.java
@@ -52,17 +52,13 @@ public class ViewModelProvider {
     @SuppressWarnings("unchecked")
     @NonNull
     public synchronized <T extends IView> ViewModelWrapper<T> getViewModel(@NonNull final String modelIdentifier,
-                                                                           @NonNull final Class<? extends AbstractViewModel<T>> viewModelClass) {
+                                                                           @NonNull final IViewModelFactory<T> viewModelFactory) {
         AbstractViewModel<T> instance = (AbstractViewModel<T>) mViewModelCache.get(modelIdentifier);
         if (instance != null) {
             return new ViewModelWrapper<>(instance, false);
         }
 
-        try {
-            instance = viewModelClass.newInstance();
-        } catch (final Exception ex) {
-            throw new RuntimeException(ex);
-        }
+        instance = viewModelFactory.createViewModel();
         instance.setUniqueIdentifier(modelIdentifier);
         mViewModelCache.put(modelIdentifier, instance);
         return new ViewModelWrapper<>(instance, true);

--- a/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java
+++ b/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java
@@ -7,6 +7,7 @@ import android.support.annotation.Nullable;
 
 import eu.inloop.viewmodel.AbstractViewModel;
 import eu.inloop.viewmodel.IView;
+import eu.inloop.viewmodel.IViewModelFactory;
 import eu.inloop.viewmodel.ViewModelHelper;
 
 public abstract class ViewModelBaseActivity<T extends IView, R extends AbstractViewModel<T>> extends ViewModelBaseEmptyActivity implements IView  {
@@ -18,7 +19,7 @@ public abstract class ViewModelBaseActivity<T extends IView, R extends AbstractV
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModeHelper.onCreate(this, savedInstanceState, getViewModelClass(), getIntent().getExtras());
+        mViewModeHelper.onCreate(this, savedInstanceState, getViewModelFactory(), getIntent().getExtras());
     }
 
     /**
@@ -31,7 +32,7 @@ public abstract class ViewModelBaseActivity<T extends IView, R extends AbstractV
     }
 
     @Nullable
-    public abstract Class<R> getViewModelClass();
+    public abstract IViewModelFactory<T> getViewModelFactory();
 
     @CallSuper
     @Override

--- a/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java
+++ b/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java
@@ -9,6 +9,7 @@ import android.view.View;
 
 import eu.inloop.viewmodel.AbstractViewModel;
 import eu.inloop.viewmodel.IView;
+import eu.inloop.viewmodel.IViewModelFactory;
 import eu.inloop.viewmodel.ViewModelHelper;
 
 public abstract class ViewModelBaseFragment<T extends IView, R extends AbstractViewModel<T>> extends Fragment implements IView {
@@ -20,11 +21,11 @@ public abstract class ViewModelBaseFragment<T extends IView, R extends AbstractV
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModeHelper.onCreate(getActivity(), savedInstanceState, getViewModelClass(), getArguments());
+        mViewModeHelper.onCreate(getActivity(), savedInstanceState, getViewModelFactory(), getArguments());
     }
 
     @Nullable
-    public abstract Class<R> getViewModelClass();
+    public abstract IViewModelFactory<T> getViewModelFactory();
 
     /**
      * Call this after your view is ready - usually on the end of {@link Fragment#onViewCreated(View, Bundle)}

--- a/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/PagerFragment.java
+++ b/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/PagerFragment.java
@@ -1,6 +1,7 @@
 package eu.inloop.viewmodel.sample.fragment;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -10,6 +11,8 @@ import android.widget.TextView;
 
 import com.squareup.leakcanary.RefWatcher;
 
+import eu.inloop.viewmodel.AbstractViewModel;
+import eu.inloop.viewmodel.IViewModelFactory;
 import eu.inloop.viewmodel.base.ViewModelBaseFragment;
 import eu.inloop.viewmodel.sample.R;
 import eu.inloop.viewmodel.sample.SampleApplication;
@@ -38,9 +41,16 @@ public class PagerFragment extends ViewModelBaseFragment<IPageView, PageModel> {
         ((TextView)view.findViewById(R.id.text)).setText(Integer.toString(getArguments().getInt("position")));
     }
 
+    @Nullable
     @Override
-    public Class<PageModel> getViewModelClass() {
-        return PageModel.class;
+    public IViewModelFactory<IPageView> getViewModelFactory() {
+        return new IViewModelFactory<IPageView>() {
+            @NonNull
+            @Override
+            public AbstractViewModel<IPageView> createViewModel() {
+                return new PageModel();
+            }
+        };
     }
 
     @Override

--- a/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/SampleBundleFragment.java
+++ b/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/SampleBundleFragment.java
@@ -1,6 +1,7 @@
 package eu.inloop.viewmodel.sample.fragment;
 
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
@@ -8,7 +9,9 @@ import android.view.View;
 import android.view.ViewGroup;
 
 import butterknife.ButterKnife;
+import eu.inloop.viewmodel.AbstractViewModel;
 import eu.inloop.viewmodel.IView;
+import eu.inloop.viewmodel.IViewModelFactory;
 import eu.inloop.viewmodel.base.ViewModelBaseFragment;
 import eu.inloop.viewmodel.sample.R;
 import eu.inloop.viewmodel.sample.viewmodel.SampleArgumentViewModel;
@@ -37,8 +40,15 @@ public class SampleBundleFragment extends ViewModelBaseFragment<IView, SampleArg
         setModelView(this);
     }
 
+    @Nullable
     @Override
-    public Class<SampleArgumentViewModel> getViewModelClass() {
-        return SampleArgumentViewModel.class;
+    public IViewModelFactory<IView> getViewModelFactory() {
+        return new IViewModelFactory<IView>() {
+            @NonNull
+            @Override
+            public AbstractViewModel<IView> createViewModel() {
+                return new SampleArgumentViewModel();
+            }
+        };
     }
 }

--- a/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/UserListFragment.java
+++ b/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/UserListFragment.java
@@ -2,6 +2,7 @@ package eu.inloop.viewmodel.sample.fragment;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,6 +19,8 @@ import java.util.List;
 
 import butterknife.ButterKnife;
 import butterknife.InjectView;
+import eu.inloop.viewmodel.AbstractViewModel;
+import eu.inloop.viewmodel.IViewModelFactory;
 import eu.inloop.viewmodel.base.ViewModelBaseFragment;
 import eu.inloop.viewmodel.sample.R;
 import eu.inloop.viewmodel.sample.SampleApplication;
@@ -42,11 +45,17 @@ public class UserListFragment extends ViewModelBaseFragment<IUserListView, UserL
         mAdapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, android.R.id.text1, new ArrayList<String>());
     }
 
+    @Nullable
     @Override
-    public Class<UserListViewModel> getViewModelClass() {
-        return UserListViewModel.class;
+    public IViewModelFactory<IUserListView> getViewModelFactory() {
+        return new IViewModelFactory<IUserListView>() {
+            @NonNull
+            @Override
+            public AbstractViewModel<IUserListView> createViewModel() {
+                return new UserListViewModel();
+            }
+        };
     }
-
 
     @Override
     public View onCreateView(LayoutInflater inflater, @Nullable ViewGroup container, @Nullable Bundle savedInstanceState) {


### PR DESCRIPTION
Big thanks to @LosoncziTamas for the idea and original pull request. 
I have reduced the original two methods `createViewModel()` and `getViewModelFactory()` into a single method where you return the ViewModel instance (or null in case you don't need a ViewModel).

This should allow you to use dependency injection without any "hacks".

**This is a breaking change.** The developers will need to replace getViewModelClass() with getViewModelFactory().

This PR is open for any suggestions. It's only my first proposal after looking at the original pull request (https://github.com/inloop/AndroidViewModel/pull/20) 
