### PR TITLE
 Allow usage of dependency injection

### DIFF
--- a/library/src/main/java/eu/inloop/viewmodel/ViewModelHelper.java
+++ b/library/src/main/java/eu/inloop/viewmodel/ViewModelHelper.java
@@ -14,6 +14,7 @@ import android.view.LayoutInflater;
 import java.util.UUID;
 
 import eu.inloop.viewmodel.binding.ViewModelBindingConfig;
+import eu.inloop.viewmodel.base.CreateViewModelCallback;
 
 public class ViewModelHelper<T extends IView, R extends AbstractViewModel<T>> {
 
@@ -39,16 +40,16 @@ public class ViewModelHelper<T extends IView, R extends AbstractViewModel<T>> {
      * @param activity           parent activity
      * @param savedInstanceState savedInstance state from {@link Activity#onCreate(Bundle)} or
      *                           {@link Fragment#onCreate(Bundle)}
-     * @param viewModelClass     the {@link Class} of your ViewModel
-     * @param arguments          pass {@link Fragment#getArguments()}  or
-     *                           {@link Activity#getIntent()}.{@link Intent#getExtras() getExtras()}
+     * @param createViewModelCallback callback for creating viewmodel
+     * @param arguments pass {@link Fragment#getArguments()}  or
+     *                  {@link Activity#getIntent()}.{@link Intent#getExtras() getExtras()}
      */
     public void onCreate(@NonNull Activity activity,
                          @Nullable Bundle savedInstanceState,
-                         @Nullable Class<? extends AbstractViewModel<T>> viewModelClass,
+                         @Nullable CreateViewModelCallback createViewModelCallback,
                          @Nullable Bundle arguments) {
         // no viewmodel for this fragment
-        if (viewModelClass == null) {
+        if (createViewModelCallback == null) {
             mViewModel = null;
             return;
         }
@@ -72,7 +73,7 @@ public class ViewModelHelper<T extends IView, R extends AbstractViewModel<T>> {
             throw new IllegalStateException("ViewModelProvider for activity " + activity + " was null."); //NON-NLS
         }
 
-        final ViewModelProvider.ViewModelWrapper<T> viewModelWrapper = viewModelProvider.getViewModel(mScreenId, viewModelClass);
+        final ViewModelProvider.ViewModelWrapper<T> viewModelWrapper = viewModelProvider.getViewModel(mScreenId, createViewModelCallback);
         //noinspection unchecked
         mViewModel = (R) viewModelWrapper.viewModel;
 

--- a/library/src/main/java/eu/inloop/viewmodel/ViewModelProvider.java
+++ b/library/src/main/java/eu/inloop/viewmodel/ViewModelProvider.java
@@ -6,6 +6,8 @@ import android.support.v4.app.FragmentActivity;
 
 import java.util.HashMap;
 
+import eu.inloop.viewmodel.base.CreateViewModelCallback;
+
 /**
  * Create and keep this class inside your Activity. Store it
  * in {@link android.support.v4.app.FragmentActivity#onRetainCustomNonConfigurationInstance()
@@ -51,21 +53,21 @@ public class ViewModelProvider {
 
     @SuppressWarnings("unchecked")
     @NonNull
-    public synchronized <T extends IView> ViewModelWrapper<T> getViewModel(@NonNull final String modelIdentifier,
-                                                                           @NonNull final Class<? extends AbstractViewModel<T>> viewModelClass) {
+    public synchronized <T extends IView> ViewModelWrapper<T> getViewModel(final String modelIdentifier,
+                                                                           @NonNull final CreateViewModelCallback createViewModelCallback) {
         AbstractViewModel<T> instance = (AbstractViewModel<T>) mViewModelCache.get(modelIdentifier);
         if (instance != null) {
             return new ViewModelWrapper<>(instance, false);
         }
 
         try {
-            instance = viewModelClass.newInstance();
-        } catch (final Exception ex) {
+            instance = createViewModelCallback.onViewModelRequested();
+            instance.setUniqueIdentifier(modelIdentifier);
+            mViewModelCache.put(modelIdentifier, instance);
+            return new ViewModelWrapper<>(instance, true);
+        } catch (Exception ex) {
             throw new RuntimeException(ex);
         }
-        instance.setUniqueIdentifier(modelIdentifier);
-        mViewModelCache.put(modelIdentifier, instance);
-        return new ViewModelWrapper<>(instance, true);
     }
 
     final static class ViewModelWrapper<T extends IView> {

--- a/library/src/main/java/eu/inloop/viewmodel/base/CreateViewModelCallback.java
+++ b/library/src/main/java/eu/inloop/viewmodel/base/CreateViewModelCallback.java
@@ -1,0 +1,8 @@
+package eu.inloop.viewmodel.base;
+
+import eu.inloop.viewmodel.AbstractViewModel;
+import eu.inloop.viewmodel.IView;
+
+public interface CreateViewModelCallback<T extends IView, R extends AbstractViewModel<T>> {
+    R onViewModelRequested();
+}

--- a/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java
+++ b/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseActivity.java
@@ -19,7 +19,12 @@ public abstract class ViewModelBaseActivity<T extends IView, R extends AbstractV
     @Override
     protected void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        mViewModeHelper.onCreate(this, savedInstanceState, getViewModelClass(), getIntent().getExtras());
+        mViewModeHelper.onCreate(this, savedInstanceState, new CreateViewModelCallback() {
+            @Override
+            public AbstractViewModel onViewModelRequested() {
+                return createViewModel();
+            }
+        }, getIntent().getExtras());
     }
 
     /**
@@ -31,8 +36,7 @@ public abstract class ViewModelBaseActivity<T extends IView, R extends AbstractV
         mViewModeHelper.setView(view);
     }
 
-    @Nullable
-    public abstract Class<R> getViewModelClass();
+    public abstract R createViewModel();
 
     @CallSuper
     @Override

--- a/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java
+++ b/library/src/main/java/eu/inloop/viewmodel/base/ViewModelBaseFragment.java
@@ -21,8 +21,16 @@ public abstract class ViewModelBaseFragment<T extends IView, R extends AbstractV
     @Override
     public void onCreate(@Nullable final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        getViewModelHelper().onCreate(getActivity(), savedInstanceState, getViewModelClass(), getArguments());
+        getViewModelHelper().onCreate(getActivity(), savedInstanceState, new CreateViewModelCallback() {
+            @Override
+            public AbstractViewModel onViewModelRequested() {
+                return createViewModel();
+            }
+        }, getArguments());
     }
+
+    @Nullable
+    public abstract R createViewModel();
 
     @CallSuper
     @Override
@@ -58,9 +66,6 @@ public abstract class ViewModelBaseFragment<T extends IView, R extends AbstractV
         getViewModelHelper().onDestroy(this);
         super.onDestroy();
     }
-
-    @Nullable
-    public abstract Class<R> getViewModelClass();
 
     /**
      * @see ViewModelHelper#getViewModel()

--- a/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/PagerFragment.java
+++ b/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/PagerFragment.java
@@ -39,9 +39,10 @@ public class PagerFragment extends ViewModelBaseFragment<IPageView, PageModel> i
         setModelView(this);
     }
 
+    @Nullable
     @Override
-    public Class<PageModel> getViewModelClass() {
-        return PageModel.class;
+    public PageModel createViewModel() {
+        return new PageModel();
     }
 
     @Override

--- a/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/SampleBindingFragment.java
+++ b/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/SampleBindingFragment.java
@@ -36,8 +36,7 @@ public class SampleBindingFragment
 
     @Nullable
     @Override
-    public Class<SampleBindingViewModel> getViewModelClass() {
-        return SampleBindingViewModel.class;
+    public SampleBindingViewModel createViewModel() {
+        return new SampleBindingViewModel();
     }
-
 }

--- a/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/SampleBundleFragment.java
+++ b/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/SampleBundleFragment.java
@@ -37,9 +37,10 @@ public class SampleBundleFragment extends ViewModelBaseFragment<IView, SampleArg
         setModelView(this);
     }
 
+    @Nullable
     @Override
-    public Class<SampleArgumentViewModel> getViewModelClass() {
-        return SampleArgumentViewModel.class;
+    public SampleArgumentViewModel createViewModel() {
+        return new SampleArgumentViewModel();
     }
 
 }

--- a/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/UserListFragment.java
+++ b/sample/src/main/java/eu/inloop/viewmodel/sample/fragment/UserListFragment.java
@@ -47,9 +47,10 @@ public class UserListFragment extends ViewModelBaseFragment<IUserListView, UserL
         mAdapter = new ArrayAdapter<>(getActivity(), android.R.layout.simple_list_item_1, android.R.id.text1, new ArrayList<String>());
     }
 
+    @Nullable
     @Override
-    public Class<UserListViewModel> getViewModelClass() {
-        return UserListViewModel.class;
+    public UserListViewModel createViewModel() {
+        return new UserListViewModel();
     }
 
     @Override


### PR DESCRIPTION
Following #17.

Method getViewModelClass replaced with createViewModel on ViewModelBaseActivity and ViewModelBaseFragment.

Instead of using `instance = viewModelClass.newInstance();` let user creates his `ViewModel` class as he wants (eg. with pure new ExampleViewModel() as in example or through various dependency injection frameworks).